### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "categories": ["pointclouds", "export"],
   "description": "Converts Supervisely Pointcloud format to KITTI 3D",
   "docker_image": "supervisely/import-export:6.73.564",
-  "instance_version": "6.15.35",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",
   "isolate": true,

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "categories": ["pointclouds", "export"],
   "description": "Converts Supervisely Pointcloud format to KITTI 3D",
-  "docker_image": "supervisely/import-export:6.73.492",
+  "docker_image": "supervisely/import-export:6.73.564",
   "instance_version": "6.15.35",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,3 @@
-supervisely==6.73.492
+supervisely==6.73.564
 open3d==0.17.0
 scikit-image==0.21.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 # cuda:11.1-cudnn8-runtime-ubuntu20.04 + py3.8 + opencv + other bacis CV packages
 # learn more here: https://github.com/supervisely/supervisely/blob/master/base_images/py/Dockerfile
-FROM supervisely/import-export:0.0.5
+FROM supervisely/import-export:6.73.564
 
 RUN apt-get update
 
 RUN pip install --disable-pip-version-check --upgrade pip 
-RUN pip install --disable-pip-version-check supervisely==6.72.122 open3d==0.17.0 scikit-image==0.21.0
+RUN pip install --disable-pip-version-check supervisely==6.73.564 open3d==0.17.0 scikit-image==0.21.0


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
